### PR TITLE
Add missing sparsepp dep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_dependencies(dg sdsl-lite)
 add_dependencies(dg dynamic)
 add_dependencies(dg gfakluge)
 add_dependencies(dg tayweeargs)
+add_dependencies(dg sparsepp)
 target_include_directories(dg PUBLIC
   "${CMAKE_SOURCE_DIR}/src"
   "${sdsl-lite_INCLUDE}"


### PR DESCRIPTION
This should fix #3, which was really about spp.hpp not being found during the actual dg build.